### PR TITLE
Fix build using MSVC 2013 by using |strncpy_s| instead of |strncpy|.

### DIFF
--- a/src/debuginfo.cpp
+++ b/src/debuginfo.cpp
@@ -217,7 +217,7 @@ sInt DebugInfo::GetNameSpaceByName(sChar *name)
   if(pp != name - 2)
   {
     sChar buffer[2048];
-    sCopyString(buffer,name,2048);
+    sCopyString(buffer,sizeof(buffer),name,2048);
 
     if(pp - name < 2048)
       buffer[pp - name] = 0;

--- a/src/pdbfile.cpp
+++ b/src/pdbfile.cpp
@@ -352,7 +352,7 @@ static sChar *BStrToString( BSTR str, sChar *defString = "", bool stripWhitespac
   {
     sInt len = sGetStringLen(defString);
     sChar *buffer = new sChar[len+1];
-    sCopyString(buffer,defString,len+1);
+    sCopyString(buffer,sizeof(buffer),defString,len+1);
 
     return buffer;
   }

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -21,9 +21,11 @@ typedef bool sBool;
 
 #define sArray std::vector
 
-inline sChar* sCopyString( sChar* a, const sChar* b, int len )
+inline void sCopyString( sChar* a, size_t a_len, const sChar* b, int b_len )
 {
-	return strncpy( a, b, len );
+	if (strncpy_s( a, a_len, b, b_len ) != 0) {
+		abort();
+	}
 }
 
 #define sCopyMem memcpy


### PR DESCRIPTION
This avoids warning C4996 regarding strncpy being deprecated.