### PR TITLE
Fix ambiguous object file names, improve perf., code cleanup

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+### 0.5.2, 2023 Aug 6
+
+- When multiple object files have the same filename, disambiguate them (output their folder name in that case too).
+- Slightly improve performance.
+
 ### 0.5.1, 2023 Aug 5
 
 - Sizer now builds on Windows, Mac and Linux. Note that it still only analyzes the *Windows* executables/PDBs, but can do that while running on Mac/Linux.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
-### 0.5.2, 2023 Aug 6
+### 0.6.0, 2023 Aug 6
 
 - When multiple object files have the same filename, disambiguate them (output their folder name in that case too).
+- Object file sizes are counted better, in the case where some of their contributions are without symbols.
+- Sizer output now also lists object files by data size.
 - Slightly improve performance.
 
 ### 0.5.1, 2023 Aug 5

--- a/src/debuginfo.hpp
+++ b/src/debuginfo.hpp
@@ -18,6 +18,15 @@ enum class SectionType
     BSS,
 };
 
+struct SymbolInfo
+{
+    std::string name;
+    int32_t namespaceIndex = 0;
+    int32_t objectFileIndex = 0;
+    uint32_t size = 0;
+    SectionType sectionType = SectionType::Unknown;
+};
+
 struct ObjectFileInfo
 {
     std::string fileDir;
@@ -35,17 +44,7 @@ struct NamespaceInfo
     uint32_t  dataSize = 0;
 };
 
-struct DISymbol
-{
-    std::string name;
-    int32_t namespaceIndex = 0;
-    int32_t objectFileIndex = 0;
-    uint32_t VA = 0;
-    uint32_t Size = 0;
-    SectionType sectionType = SectionType::Unknown;
-};
-
-struct TemplateSymbol
+struct TemplateInfo
 {
     std::string name;
     uint32_t size = 0;
@@ -71,15 +70,12 @@ struct DebugFilters
 class DebugInfo
 {
 public:
-    std::vector<DISymbol>  Symbols;
-    std::vector<TemplateSymbol>  Templates;
-
-    void FinishedReading();
+    std::vector<SymbolInfo>  m_Symbols;
 
     int32_t GetObjectFileIndex(const char* pathStr);
     int32_t GetNameSpaceIndex(const std::string& symName);
 
-    void FinishAnalyze();
+    void ComputeDerivedData();
 
     std::string WriteReport(const DebugFilters& filters);
 
@@ -94,4 +90,6 @@ private:
     std::vector<ObjectFileInfo> m_ObjectFiles;
     std::map<std::string, int32_t> m_ObjectPathToIndex;
     std::map<std::string, std::set<std::string>> m_ObjectNameToFolders;
+
+    std::vector<TemplateInfo> m_Templates;
 };

--- a/src/debuginfo.hpp
+++ b/src/debuginfo.hpp
@@ -3,18 +3,19 @@
 // Based on code by Fabian "ryg" Giesen, http://farbrausch.com/~fg/
 // Public domain.
 
-#ifndef __DEBUGINFO_HPP__
-#define __DEBUGINFO_HPP__
+#pragma once
 
 #include <map>
 #include <string>
 #include <vector>
 
-#define DIC_END     0
-#define DIC_CODE    1
-#define DIC_DATA    2
-#define DIC_BSS     3 // uninitialized data
-#define DIC_UNKNOWN 4
+enum class SectionType
+{
+    Unknown,
+    Code,
+    Data,
+    BSS,
+};
 
 struct DISymFile // File
 {
@@ -25,26 +26,26 @@ struct DISymFile // File
 
 struct DISymNameSp // Namespace
 {
-    int32_t  name;
-    uint32_t  codeSize;
-    uint32_t  dataSize;
+    int32_t  name = 0;
+    uint32_t  codeSize = 0;
+    uint32_t  dataSize = 0;
 };
 
 struct DISymbol
 {
     std::string name;
-    int32_t NameSpNum;
-    int32_t objFileNum;
-    uint32_t VA;
-    uint32_t Size;
-    int32_t Class;
+    int32_t NameSpNum = 0;
+    int32_t objFileNum = 0;
+    uint32_t VA = 0;
+    uint32_t Size = 0;
+    SectionType sectionType = SectionType::Unknown;
 };
 
 struct TemplateSymbol
 {
     std::string name;
-    uint32_t size;
-    uint32_t count;
+    uint32_t size = 0;
+    uint32_t count = 0;
 };
 
 struct DebugFilters
@@ -73,7 +74,7 @@ class DebugInfo
     IndexByStringMap  m_IndexByString;
     NameIndexToArrayIndexMap m_NameSpaceIndexByName;
 
-    uint32_t CountSizeInClass(int32_t type) const;
+    uint32_t CountSizeInSection(SectionType type) const;
 
 public:
     std::vector<DISymbol>  Symbols;
@@ -98,12 +99,3 @@ public:
 
     std::string WriteReport(const DebugFilters& filters);
 };
-
-class DebugInfoReader
-{
-public:
-    virtual bool ReadDebugInfo(const char *fileName, DebugInfo &to) = 0;
-};
-
-
-#endif

--- a/src/debuginfo.hpp
+++ b/src/debuginfo.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -17,11 +18,13 @@ enum class SectionType
     BSS,
 };
 
-struct DISymFile // File
+struct ObjectFileInfo
 {
-    int32_t  fileName;
-    uint32_t  codeSize;
-    uint32_t  dataSize;
+    std::string fileDir;
+    std::string fileName;
+    int32_t index = 0;
+    uint32_t codeSize = 0;
+    uint32_t dataSize = 0;
 };
 
 struct DISymNameSp // Namespace
@@ -35,7 +38,7 @@ struct DISymbol
 {
     std::string name;
     int32_t NameSpNum = 0;
-    int32_t objFileNum = 0;
+    int32_t objectFileIndex = 0;
     uint32_t VA = 0;
     uint32_t Size = 0;
     SectionType sectionType = SectionType::Unknown;
@@ -66,20 +69,9 @@ struct DebugFilters
 
 class DebugInfo
 {
-    typedef std::vector<std::string>   StringByIndexVector;
-    typedef std::map<std::string, int32_t> IndexByStringMap;
-    typedef std::map<int32_t, int32_t> NameIndexToArrayIndexMap;
-
-    StringByIndexVector m_StringByIndex;
-    IndexByStringMap  m_IndexByString;
-    NameIndexToArrayIndexMap m_NameSpaceIndexByName;
-
-    uint32_t CountSizeInSection(SectionType type) const;
-
 public:
     std::vector<DISymbol>  Symbols;
     std::vector<TemplateSymbol>  Templates;
-    std::vector<DISymFile> m_Files;
     std::vector<DISymNameSp> NameSps;
 
     int32_t MakeStringPtr(const char *s);
@@ -88,8 +80,7 @@ public:
 
     void FinishedReading();
 
-    int32_t GetFile(int32_t fileName);
-    int32_t GetFileByName(const char *objName);
+    int32_t GetObjectFileIndexByPath(const char* pathStr);
 
     int32_t GetNameSpace(int32_t name);
     int32_t GetNameSpaceByName(const char *name);
@@ -98,4 +89,21 @@ public:
     void FinishAnalyze();
 
     std::string WriteReport(const DebugFilters& filters);
+
+private:
+    uint32_t CountSizeInSection(SectionType type) const;
+    std::string GetObjectFileDesc(int index) const;
+
+private:
+    typedef std::vector<std::string>   StringByIndexVector;
+    typedef std::map<std::string, int32_t> IndexByStringMap;
+    typedef std::map<int32_t, int32_t> NameIndexToArrayIndexMap;
+
+    StringByIndexVector m_StringByIndex;
+    IndexByStringMap  m_IndexByString;
+    NameIndexToArrayIndexMap m_NameSpaceIndexByName;
+
+    std::vector<ObjectFileInfo> m_ObjectFiles;
+    std::map<std::string, int32_t> m_ObjectPathToIndex;
+    std::map<std::string, std::set<std::string>> m_ObjectNameToFolders;
 };

--- a/src/debuginfo.hpp
+++ b/src/debuginfo.hpp
@@ -27,9 +27,10 @@ struct ObjectFileInfo
     uint32_t dataSize = 0;
 };
 
-struct DISymNameSp // Namespace
+struct NamespaceInfo
 {
-    int32_t  name = 0;
+    std::string name;
+    int32_t index = 0;
     uint32_t  codeSize = 0;
     uint32_t  dataSize = 0;
 };
@@ -37,7 +38,7 @@ struct DISymNameSp // Namespace
 struct DISymbol
 {
     std::string name;
-    int32_t NameSpNum = 0;
+    int32_t namespaceIndex = 0;
     int32_t objectFileIndex = 0;
     uint32_t VA = 0;
     uint32_t Size = 0;
@@ -72,20 +73,12 @@ class DebugInfo
 public:
     std::vector<DISymbol>  Symbols;
     std::vector<TemplateSymbol>  Templates;
-    std::vector<DISymNameSp> NameSps;
-
-    int32_t MakeStringPtr(const char *s);
-    int32_t MakeStringStd(const std::string& s);
-    const char* GetStringPrep(int32_t index) const { return m_StringByIndex[index].c_str(); }
 
     void FinishedReading();
 
-    int32_t GetObjectFileIndexByPath(const char* pathStr);
+    int32_t GetObjectFileIndex(const char* pathStr);
+    int32_t GetNameSpaceIndex(const std::string& symName);
 
-    int32_t GetNameSpace(int32_t name);
-    int32_t GetNameSpaceByName(const char *name);
-
-    void StartAnalyze();
     void FinishAnalyze();
 
     std::string WriteReport(const DebugFilters& filters);
@@ -95,13 +88,8 @@ private:
     std::string GetObjectFileDesc(int index) const;
 
 private:
-    typedef std::vector<std::string>   StringByIndexVector;
-    typedef std::map<std::string, int32_t> IndexByStringMap;
-    typedef std::map<int32_t, int32_t> NameIndexToArrayIndexMap;
-
-    StringByIndexVector m_StringByIndex;
-    IndexByStringMap  m_IndexByString;
-    NameIndexToArrayIndexMap m_NameSpaceIndexByName;
+    std::vector<NamespaceInfo> m_Namespaces;
+    std::map<std::string, int32_t> m_NamespaceToIndex;
 
     std::vector<ObjectFileInfo> m_ObjectFiles;
     std::map<std::string, int32_t> m_ObjectPathToIndex;

--- a/src/debuginfo.hpp
+++ b/src/debuginfo.hpp
@@ -27,6 +27,13 @@ struct SymbolInfo
     SectionType sectionType = SectionType::Unknown;
 };
 
+struct ContribInfo
+{
+    int32_t objectFileIndex = 0;
+    uint32_t size = 0;
+    SectionType sectionType = SectionType::Unknown;
+};
+
 struct ObjectFileInfo
 {
     std::string fileDir;
@@ -34,6 +41,8 @@ struct ObjectFileInfo
     int32_t index = 0;
     uint32_t codeSize = 0;
     uint32_t dataSize = 0;
+    uint32_t contribCodeSize = 0;
+    uint32_t contribDataSize = 0;
 };
 
 struct NamespaceInfo
@@ -71,6 +80,7 @@ class DebugInfo
 {
 public:
     std::vector<SymbolInfo>  m_Symbols;
+    std::vector<ContribInfo> m_Contribs;
 
     int32_t GetObjectFileIndex(const char* pathStr);
     int32_t GetNameSpaceIndex(const std::string& symName);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,6 @@ int main(int argc, char * const * argv)
     }
     fprintf(stderr, "\nProcessing info...\n");
     info.FinishedReading();
-    info.StartAnalyze();
     info.FinishAnalyze();
 
     fprintf(stderr, "Generating report...\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,8 +122,7 @@ int main(int argc, char * const * argv)
         return 1;
     }
     fprintf(stderr, "\nProcessing info...\n");
-    info.FinishedReading();
-    info.FinishAnalyze();
+    info.ComputeDerivedData();
 
     fprintf(stderr, "Generating report...\n");
     std::string report = info.WriteReport(filters);

--- a/src/pdbfile.cpp
+++ b/src/pdbfile.cpp
@@ -25,7 +25,7 @@ struct SectionContrib
     uint32_t Length;
     uint32_t Compiland;
     SectionType Type;
-    int32_t ObjFile;
+    int32_t ObjFileIndex;
 };
 
 struct PDBSymbol
@@ -71,11 +71,11 @@ typedef std::unordered_map<uint32_t, PDBSymbol> RVAToSymbolMap;
 static void AddSymbol(const SectionContrib* contribs, size_t contribsCount, uint32_t section, uint32_t offset, const std::string& name, uint32_t length, uint32_t rva, DebugInfo& to)
 {
     const SectionContrib* contrib = ContribFromSectionOffset(contribs, contribsCount, section, offset);
-    int32_t objFile = 0;
+    int32_t objFileIndex = 0;
     SectionType sectionType = SectionType::Unknown;
     if (contrib)
     {
-        objFile = contrib->ObjFile;
+        objFileIndex = contrib->ObjFileIndex;
         sectionType = contrib->Type;
         if (length == 0)
             length = contrib->Length;
@@ -83,7 +83,7 @@ static void AddSymbol(const SectionContrib* contribs, size_t contribsCount, uint
 
     DISymbol outSym;
     outSym.name = name.empty() ? "<noname>" : name;
-    outSym.objFileNum = objFile;
+    outSym.objectFileIndex = objFileIndex;
     outSym.VA = rva;
     outSym.Size = length;
     outSym.sectionType = sectionType;
@@ -228,7 +228,7 @@ static void ReadEverything(const PDB::RawFile& rawPdbFile, const PDB::DBIStream&
             contrib.Type = SectionType::Unknown;
 
         const PDB::ModuleInfoStream::Module& module = moduleInfoStream.GetModule(srcContrib.moduleIndex);
-        contrib.ObjFile = to.GetFileByName(module.GetName().Decay());
+        contrib.ObjFileIndex = to.GetObjectFileIndexByPath(module.GetName().Decay());
         contributions.emplace_back(contrib);
     }
 

--- a/src/pdbfile.cpp
+++ b/src/pdbfile.cpp
@@ -87,7 +87,7 @@ static void AddSymbol(const SectionContrib* contribs, size_t contribsCount, uint
     outSym.VA = rva;
     outSym.Size = length;
     outSym.sectionType = sectionType;
-    outSym.NameSpNum = to.GetNameSpaceByName(name.c_str());
+    outSym.namespaceIndex = to.GetNameSpaceIndex(name);
 
     to.Symbols.emplace_back(outSym);
 }
@@ -228,7 +228,7 @@ static void ReadEverything(const PDB::RawFile& rawPdbFile, const PDB::DBIStream&
             contrib.Type = SectionType::Unknown;
 
         const PDB::ModuleInfoStream::Module& module = moduleInfoStream.GetModule(srcContrib.moduleIndex);
-        contrib.ObjFileIndex = to.GetObjectFileIndexByPath(module.GetName().Decay());
+        contrib.ObjFileIndex = to.GetObjectFileIndex(module.GetName().Decay());
         contributions.emplace_back(contrib);
     }
 

--- a/src/pdbfile.cpp
+++ b/src/pdbfile.cpp
@@ -189,6 +189,7 @@ static void ReadEverything(const PDB::RawFile& rawPdbFile, const PDB::DBIStream&
     std::vector<SectionContrib> contributions;
     size_t sectionContribsSize = sectionContributions.GetLength();
     contributions.reserve(sectionContribsSize);
+    to.m_Contribs.reserve(sectionContribsSize);
 
     size_t processedContribsCount = 0;
     for (const PDB::DBI::SectionContribution& srcContrib : sectionContributions)
@@ -229,6 +230,12 @@ static void ReadEverything(const PDB::RawFile& rawPdbFile, const PDB::DBIStream&
         const PDB::ModuleInfoStream::Module& module = moduleInfoStream.GetModule(srcContrib.moduleIndex);
         contrib.ObjFileIndex = to.GetObjectFileIndex(module.GetName().Decay());
         contributions.emplace_back(contrib);
+
+        ContribInfo info;
+        info.objectFileIndex = contrib.ObjFileIndex;
+        info.sectionType = contrib.Type;
+        info.size = contrib.Length;
+        to.m_Contribs.emplace_back(info);
     }
 
     RVAToSymbolMap rvaToSymbol;

--- a/src/pdbfile.cpp
+++ b/src/pdbfile.cpp
@@ -68,7 +68,7 @@ static const SectionContrib* ContribFromSectionOffset(const SectionContrib* cont
 typedef std::unordered_map<uint32_t, PDBSymbol> RVAToSymbolMap;
 
 
-static void AddSymbol(const SectionContrib* contribs, size_t contribsCount, uint32_t section, uint32_t offset, const std::string& name, uint32_t length, uint32_t rva, DebugInfo& to)
+static void AddSymbol(const SectionContrib* contribs, size_t contribsCount, uint32_t section, uint32_t offset, const std::string& name, uint32_t length, DebugInfo& to)
 {
     const SectionContrib* contrib = ContribFromSectionOffset(contribs, contribsCount, section, offset);
     int32_t objFileIndex = 0;
@@ -81,15 +81,14 @@ static void AddSymbol(const SectionContrib* contribs, size_t contribsCount, uint
             length = contrib->Length;
     }
 
-    DISymbol outSym;
+    SymbolInfo outSym;
     outSym.name = name.empty() ? "<noname>" : name;
     outSym.objectFileIndex = objFileIndex;
-    outSym.VA = rva;
-    outSym.Size = length;
+    outSym.size = length;
     outSym.sectionType = sectionType;
     outSym.namespaceIndex = to.GetNameSpaceIndex(name);
 
-    to.Symbols.emplace_back(outSym);
+    to.m_Symbols.emplace_back(outSym);
 }
 
 static void ProcessSymbol(const PDB::ImageSectionStream& imageSectionStream, const PDB::CodeView::DBI::Record* record, RVAToSymbolMap& toMap)
@@ -341,7 +340,7 @@ static void ReadEverything(const PDB::RawFile& rawPdbFile, const PDB::DBIStream&
         ++addedSymbolCount;
         if ((addedSymbolCount & 65535) == 0)
             fprintf(stderr, "\b\b\b\b\b\b\b\b[%5.1f%%]", 50.0 + addedSymbolCount * 50.0 / symbolCount);
-        AddSymbol(contributions.data(), contributions.size(), sym.section, sym.offset, sym.name, sym.length, sym.rva, to);
+        AddSymbol(contributions.data(), contributions.size(), sym.section, sym.offset, sym.name, sym.length, to);
     }
 }
 


### PR DESCRIPTION
- When multiple object files have the same filename, disambiguate them (output their folder name in that case too).
- Slightly improve performance.